### PR TITLE
Test cleanups

### DIFF
--- a/test/fixtures/docker-mock.js
+++ b/test/fixtures/docker-mock.js
@@ -1,10 +1,11 @@
 'use strict';
 var spawn = require('child_process').fork;
+var debug = require('debug')('test-docker-mock');
 
 module.exports.start = function (cb) {
   this.server = spawn('test/fixtures/docker-server.js');
 
-  console.log('Spawned child pid: ' + this.server.pid);
+  debug('Spawned child pid: ', this.server.pid);
   this.server.on('message', function (msg) {
     if (msg === 'started') {
       cb();
@@ -15,7 +16,7 @@ module.exports.start = function (cb) {
 module.exports.stop = function (cb) {
   if (this.server) {
     this.server.on('exit', function (code) {
-      console.log('docker server process exited with code ' + code);
+      debug('docker server process exited with code ', code);
       cb();
     });
     this.server.kill('SIGHUP');

--- a/test/fixtures/docker-server.js
+++ b/test/fixtures/docker-server.js
@@ -1,9 +1,10 @@
 'use strict';
 var app = require('docker-mock');
+var debug = require('debug')('test-docker-server');
 
 app.listen(4243, function (err) {
   if (err) { throw err; }
-  console.log('started docker mock');
+  debug('started docker mock');
   process.send('started');
 });
 

--- a/test/listener.js
+++ b/test/listener.js
@@ -8,7 +8,6 @@ var it = lab.test;
 var expect = Code.expect;
 var beforeEach = lab.beforeEach;
 var afterEach = lab.afterEach;
-// var after = lab.after;
 
 
 var cbCount = require('callback-count');

--- a/test/listener.js
+++ b/test/listener.js
@@ -127,7 +127,7 @@ describe('listener', function () {
       var ws = new stream.Stream();
       ws.writable = true;
       var messagesCounter = 0;
-      ws.write = function (data) {
+      ws.write = function () {
         if (messagesCounter === 8) {
           listener.stop(function () {
             setTimeout(function () {

--- a/test/listener.js
+++ b/test/listener.js
@@ -109,12 +109,10 @@ describe('listener', function () {
   describe('close', function () {
 
     beforeEach(function (done) {
-      process.env.AUTO_RECONNECT = 'false';
       ctx.docker = docker.start(done);
     });
 
     afterEach(function (done) {
-      process.env.AUTO_RECONNECT = 'false';
       ctx.docker.stop(done);
     });
 

--- a/test/listener.js
+++ b/test/listener.js
@@ -47,11 +47,8 @@ describe('listener', function () {
 
     function restartDocker (ctx) {
       ctx.docker.stop(function(){
-        console.log('closed docker');
         setTimeout(function () {
-          ctx.docker = docker.start(function () {
-            console.log('docker is up again');
-          });
+          ctx.docker = docker.start(function () {});
         }, 1000);
       });
     }

--- a/test/listener.js
+++ b/test/listener.js
@@ -7,6 +7,8 @@ var describe = lab.experiment;
 var it = lab.test;
 var expect = Code.expect;
 var beforeEach = lab.beforeEach;
+var afterEach = lab.afterEach;
+// var after = lab.after;
 
 
 var cbCount = require('callback-count');
@@ -14,6 +16,7 @@ var stream = require('stream');
 var listener = require('../lib/listener.js');
 var docker = require('./fixtures/docker-mock.js');
 var ip = require('ip');
+var debug = require('debug')('test-listener');
 
 describe('listener', function () {
   var ctx = {};
@@ -45,24 +48,21 @@ describe('listener', function () {
       ctx.docker = docker.start(done);
     });
 
-    function restartDocker (ctx) {
-      ctx.docker.stop(function(){
-        setTimeout(function () {
-          ctx.docker = docker.start(function () {});
-        }, 1000);
-      });
-    }
+    afterEach(function (done) {
+      process.env.AUTO_RECONNECT = 'false';
+      ctx.docker.stop(done);
+    });
+
+    afterEach(function (done) {
+      listener.stop(done);
+    });
+
     // receive 4 good events.
     // stop docker and receive docker_daemon_down event
     // start docker and receive docker_daemon_up
     // receive good events for the rest
     it('should handle case when docker was working and than down for some time', function (done) {
-      var count = cbCount(10, function () {
-        process.env.AUTO_RECONNECT = 'false';
-        ctx.docker.stop(function () {
-          done();
-        });
-      });
+      var count = cbCount(10, done);
       var ws = new stream.Stream();
       ws.writable = true;
       var messagesCounter = 0;
@@ -100,9 +100,65 @@ describe('listener', function () {
         }
       };
       ws.end = function () {
-        console.log('disconnect');
+        debug('disconnect');
       };
       listener.start(ws, function () {});
     });
   });
+
+  describe('close', function () {
+
+    beforeEach(function (done) {
+      process.env.AUTO_RECONNECT = 'false';
+      ctx.docker = docker.start(done);
+    });
+
+    afterEach(function (done) {
+      process.env.AUTO_RECONNECT = 'false';
+      ctx.docker.stop(done);
+    });
+
+    afterEach(function (done) {
+      listener.stop(done);
+    });
+
+
+    it('should stop receiving events after close was called', function (done) {
+      var ws = new stream.Stream();
+      ws.writable = true;
+      var messagesCounter = 0;
+      ws.write = function (data) {
+        if (messagesCounter === 8) {
+          listener.stop(function () {
+            setTimeout(function () {
+              // check that messageCounter === 9
+              // we didn't received any new messages after stop was called
+              if (messagesCounter === 9) {
+                done();
+              }
+              else {
+                done(new Error('Streaming never stopped'));
+              }
+            }, 500);
+          });
+        }
+        messagesCounter++;
+      };
+      ws.end = function () {
+        debug('disconnect');
+      };
+      listener.start(ws, function () {});
+    });
+
+  });
+
+
 });
+
+function restartDocker (ctx) {
+  ctx.docker.stop(function(){
+    setTimeout(function () {
+      ctx.docker = docker.start(function () {});
+    }, 1000);
+  });
+}


### PR DESCRIPTION
Remove `console.log` from the code.

Add test for the `listener.close` method: check that events are not publishing to the redis anymore after `close` was called.
