### PR TITLE
update to hermes-private 6.0 with new queue name

### DIFF
--- a/lib/hermes-client.js
+++ b/lib/hermes-client.js
@@ -10,6 +10,7 @@ require('loadenv')();
 
 if (process.env.RABBITMQ_HOSTNAME) {
   module.exports = require('hermes-private').hermesSingletonFactory({
+    heartbeat: 10,
     hostname: process.env.RABBITMQ_HOSTNAME,
     password: process.env.RABBITMQ_PASSWORD,
     port: process.env.RABBITMQ_PORT,

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -69,8 +69,8 @@ RedisPublisherStream.prototype._write = function (chunk, encoding, callback) {
           log.info(logData, 'inserting on-instance-container-create task into queue');
           hermesClient.publish('on-instance-container-create', enhanced);
         } else if (isBuildContainer(enhanced)) {
-          log.info(logData, 'inserting on-create-start-image-builder-container task into queue');
-          hermesClient.publish('on-create-start-image-builder-container', enhanced);
+          log.info(logData, 'inserting on-image-builder-container-create task into queue');
+          hermesClient.publish('on-image-builder-container-create', enhanced);
         }
         break;
       case 'die':

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-uuid": "^1.4.1",
     "redis": "^0.12.1",
     "rollbar": "^0.3.13",
-    "hermes-private": "git+ssh://git@github.com:CodeNow/hermes-private#v5.1.0"
+    "hermes-private": "git+ssh://git@github.com:CodeNow/hermes-private#v6.0.0"
   },
   "devDependencies": {
     "callback-count": "^0.1.0",


### PR DESCRIPTION
Requires this PR to be merged and tagged with v6.0.0 before tests will run/pass
https://github.com/CodeNow/hermes-private/pull/5
