### PR TITLE
SAN-3443 - do not throw a fatal error

### DIFF
--- a/lib/workers/docker.event.publish.js
+++ b/lib/workers/docker.event.publish.js
@@ -88,7 +88,7 @@ function DockerEventPublish (job) {
           break
         default:
           log.info(logData, 'DockerEventPublish - we do not handle event with this status')
-          throw new TaskFatalError('docker.event.publish', 'Paylod status is invalid')
+          return
       }
     })
 }

--- a/test/worker-docker.event.publish.js
+++ b/test/worker-docker.event.publish.js
@@ -505,14 +505,13 @@ describe('docker event publish', function () {
         done()
       })
     })
-    it('should fail for invalid event', function (done) {
+    it('should do nothing for invalid event', function (done) {
       var payload = {
         status: 'invalid-event',
         id: 'bc533791f3f500b280a9626688bc79e342e3ea0d528efe3a86a51ecb28ea20'
       }
       DockerEventPublish(payload).asCallback(function (err) {
-        expect(err).to.be.instanceOf(TaskFatalError)
-        expect(err.message).to.contain('Paylod status is invalid')
+        expect(err).to.not.exist()
         sinon.assert.calledOnce(DockerEventPublish._addBasicFields)
         sinon.assert.calledWith(DockerEventPublish._addBasicFields, payload)
         sinon.assert.calledOnce(DockerEventPublish._isContainerEvent)


### PR DESCRIPTION
We shouldn't throw an TaskFatalError for events we don't care. Just do nothing.
- [x] @bkendall
