### PR TITLE
Update ponos to version 3.0.1 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@runnable/loki": "^1.0.0",
     "monitor-dog": "^1.5.0",
     "node-uuid": "^1.4.7",
-    "ponos": "^2.0.0",
+    "ponos": "^3.0.1",
     "runnable-hermes": "^6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[ponos](https://www.npmjs.com/package/ponos) just published its new version 3.0.1, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of ponos – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 92 commits .
- [`804d9a2`](https://github.com/Runnable/ponos/commit/804d9a2539844780c0ff3fb01e3ca1825d597481) `3.0.1`
- [`6075d23`](https://github.com/Runnable/ponos/commit/6075d23337d5b3ca5a6dc974a54681d2b1e0b5ac) `add link to migration guide`
- [`b2c9261`](https://github.com/Runnable/ponos/commit/b2c9261d743d47cca1f20a6515f3345a4c71631d) `changelog@v3.0.0`
- [`df45165`](https://github.com/Runnable/ponos/commit/df45165b65dfc7cf6f44864be170105f512387b1) `3.0.0`
- [`db5dba4`](https://github.com/Runnable/ponos/commit/db5dba4889acd9f04ff5c7faa77353ff90c05762) `Merge pull request #43 from Runnable/three-master`
- [`4d199b1`](https://github.com/Runnable/ponos/commit/4d199b180a1c0c384aebc85d420c92925ce798a3) `little doc tweaks`
- [`c92e915`](https://github.com/Runnable/ponos/commit/c92e9153fdb3731859dc6ff2bef277e036a800ac) `add migration guide for v3.0.0`
- [`b9b7ffe`](https://github.com/Runnable/ponos/commit/b9b7ffed20809eacb72cb47acb00d5b15a3bce53) `Merge pull request #42 from Runnable/publish-methods`
- [`7bd6df6`](https://github.com/Runnable/ponos/commit/7bd6df66117b1783328c8240f9162da81d7d0336) `fix some spelling`
- [`cd4f1c6`](https://github.com/Runnable/ponos/commit/cd4f1c66461291d38279026828789509c768bb92) `remove console.log`
- [`f3f901d`](https://github.com/Runnable/ponos/commit/f3f901d2873125eae3fc530a24d3da8569a89af9) `fix type issues`
- [`01d98ed`](https://github.com/Runnable/ponos/commit/01d98ed2fb19757699d5e311a955888d182f5c86) `use new rabbitmq methods for publishing`
- [`f350bcb`](https://github.com/Runnable/ponos/commit/f350bcbcd295f414b06190095b135f03d84e8618) `update some documentation`
- [`7458f85`](https://github.com/Runnable/ponos/commit/7458f851302312051cf3985aa7942972959d3635) `add publishing methods`
- [`8229196`](https://github.com/Runnable/ponos/commit/8229196a8363d36df4b766d61e515d343e2248c5) `Merge pull request #41 from Runnable/name-client`

There are 92 commits in total. See the [full diff](https://github.com/Runnable/ponos/compare/18adf3aa52bdc93b46971c3b8b69114fcbf40b34...804d9a2539844780c0ff3fb01e3ca1825d597481).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
