### PR TITLE
Update ponos to version 3.0.2 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@runnable/loki": "^1.0.0",
     "monitor-dog": "^1.5.0",
     "node-uuid": "^1.4.7",
-    "ponos": "^2.0.0",
+    "ponos": "^3.0.2",
     "runnable-hermes": "^6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[ponos](https://www.npmjs.com/package/ponos) just published its new version 3.0.2, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of ponos – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 100 commits .
- [`41f219f`](https://github.com/Runnable/ponos/commit/41f219fd8fc7a3a5a134f4b4040838b9a607ab33) `3.0.2`
- [`bbada46`](https://github.com/Runnable/ponos/commit/bbada46d4074aaaabb27d40aab7822c6445476ad) `Merge pull request #46 from Runnable/confirm-publish-messages`
- [`ad139b4`](https://github.com/Runnable/ponos/commit/ad139b4a4a7293d1e1f69f9feafc574cf6be0a7c) `move tests for waitForConfirms`
- [`f44efd8`](https://github.com/Runnable/ponos/commit/f44efd8b524218fe89e11f73630709cb850bf07d) `wait for all published messages when closing`
- [`2e3f987`](https://github.com/Runnable/ponos/commit/2e3f9872731496acb30bdb4a4ea79b2f198368f4) `create a confirm queue and confirm messages that are published`
- [`8f4ac7a`](https://github.com/Runnable/ponos/commit/8f4ac7a094163c56378941bc899856a11d639358) `add interface for confirm channels`
- [`891f72e`](https://github.com/Runnable/ponos/commit/891f72e748666c4b4f64495ca9c007da970f60e9) `Merge pull request #44 from Runnable/greenkeeper-flow-bin-0.25.0`
- [`11afb96`](https://github.com/Runnable/ponos/commit/11afb96f9a3521e6e2525d82365bb9062c13ba17) `chore(package): update flow-bin to version 0.25.0`
- [`804d9a2`](https://github.com/Runnable/ponos/commit/804d9a2539844780c0ff3fb01e3ca1825d597481) `3.0.1`
- [`6075d23`](https://github.com/Runnable/ponos/commit/6075d23337d5b3ca5a6dc974a54681d2b1e0b5ac) `add link to migration guide`
- [`b2c9261`](https://github.com/Runnable/ponos/commit/b2c9261d743d47cca1f20a6515f3345a4c71631d) `changelog@v3.0.0`
- [`df45165`](https://github.com/Runnable/ponos/commit/df45165b65dfc7cf6f44864be170105f512387b1) `3.0.0`
- [`db5dba4`](https://github.com/Runnable/ponos/commit/db5dba4889acd9f04ff5c7faa77353ff90c05762) `Merge pull request #43 from Runnable/three-master`
- [`4d199b1`](https://github.com/Runnable/ponos/commit/4d199b180a1c0c384aebc85d420c92925ce798a3) `little doc tweaks`
- [`c92e915`](https://github.com/Runnable/ponos/commit/c92e9153fdb3731859dc6ff2bef277e036a800ac) `add migration guide for v3.0.0`

There are 100 commits in total. See the [full diff](https://github.com/Runnable/ponos/compare/18adf3aa52bdc93b46971c3b8b69114fcbf40b34...41f219fd8fc7a3a5a134f4b4040838b9a607ab33).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
