### PR TITLE
Update ponos to version 3.1.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@runnable/loki": "^1.0.0",
     "monitor-dog": "^1.5.0",
     "node-uuid": "^1.4.7",
-    "ponos": "^2.0.0",
+    "ponos": "^3.1.0",
     "runnable-hermes": "^6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[ponos](https://www.npmjs.com/package/ponos) just published its new version 3.1.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of ponos – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 107 commits .
- [`4d820c6`](https://github.com/Runnable/ponos/commit/4d820c60d02ba0b17ec4e0485c1328770adf64ed) `3.1.0`
- [`4eb2cc7`](https://github.com/Runnable/ponos/commit/4eb2cc7ed447d94234df29189782524f99ebbecc) `Merge pull request #48 from Runnable/prefetch`
- [`0bed566`](https://github.com/Runnable/ponos/commit/0bed5667489c2e08ad72d7101b83ae78c9fc9345) `add ability to set prefetch for channel`
- [`6f5dbbc`](https://github.com/Runnable/ponos/commit/6f5dbbc23ab4342691c39113f7cf58deea428578) `Merge pull request #47 from Runnable/greenkeeper-mocha-2.5.0`
- [`f697701`](https://github.com/Runnable/ponos/commit/f697701b0f9d918301949a2946af9899c31e8f38) `mocha@2.5.1`
- [`b8687d9`](https://github.com/Runnable/ponos/commit/b8687d9150d2ea767964f6a17e16288b5f51339d) `chore(package): update mocha to version 2.5.0`
- [`9f23436`](https://github.com/Runnable/ponos/commit/9f2343659902adf7a9c34e62eda7caab43c35d12) `changelog@v3.0.2`
- [`41f219f`](https://github.com/Runnable/ponos/commit/41f219fd8fc7a3a5a134f4b4040838b9a607ab33) `3.0.2`
- [`bbada46`](https://github.com/Runnable/ponos/commit/bbada46d4074aaaabb27d40aab7822c6445476ad) `Merge pull request #46 from Runnable/confirm-publish-messages`
- [`ad139b4`](https://github.com/Runnable/ponos/commit/ad139b4a4a7293d1e1f69f9feafc574cf6be0a7c) `move tests for waitForConfirms`
- [`f44efd8`](https://github.com/Runnable/ponos/commit/f44efd8b524218fe89e11f73630709cb850bf07d) `wait for all published messages when closing`
- [`2e3f987`](https://github.com/Runnable/ponos/commit/2e3f9872731496acb30bdb4a4ea79b2f198368f4) `create a confirm queue and confirm messages that are published`
- [`8f4ac7a`](https://github.com/Runnable/ponos/commit/8f4ac7a094163c56378941bc899856a11d639358) `add interface for confirm channels`
- [`891f72e`](https://github.com/Runnable/ponos/commit/891f72e748666c4b4f64495ca9c007da970f60e9) `Merge pull request #44 from Runnable/greenkeeper-flow-bin-0.25.0`
- [`11afb96`](https://github.com/Runnable/ponos/commit/11afb96f9a3521e6e2525d82365bb9062c13ba17) `chore(package): update flow-bin to version 0.25.0`

There are 107 commits in total. See the [full diff](https://github.com/Runnable/ponos/compare/18adf3aa52bdc93b46971c3b8b69114fcbf40b34...4d820c60d02ba0b17ec4e0485c1328770adf64ed).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
