### PR TITLE
Update ponos to version 3.2.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@runnable/loki": "^1.0.0",
     "monitor-dog": "^1.5.0",
     "node-uuid": "^1.4.7",
-    "ponos": "^2.0.0",
+    "ponos": "^3.2.0",
     "runnable-hermes": "^6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[ponos](https://www.npmjs.com/package/ponos) just published its new version 3.2.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of ponos – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 115 commits .
- [`bc88408`](https://github.com/Runnable/ponos/commit/bc88408c43bf9ee440ce26894e649dc90da138bf) `3.2.0`
- [`dae201d`](https://github.com/Runnable/ponos/commit/dae201d3ba86ae29bd2618679ee6f72ab3722c0f) `Merge pull request #51 from Runnable/publish-methods`
- [`ec1b9d7`](https://github.com/Runnable/ponos/commit/ec1b9d72cc9a04e1469074429be365d109c1a281) `still include publishToQueue and Exchange for backwards compatability`
- [`74ae886`](https://github.com/Runnable/ponos/commit/74ae88662d9da103b3f31a22174d83ade9e64d38) `rename publish methods to publishTask and Event`
- [`f589e99`](https://github.com/Runnable/ponos/commit/f589e997ee95eb6d0a3d1ab704c38ebfa3aeb202) `Merge pull request #50 from Runnable/greenkeeper-flow-bin-0.26.0`
- [`053f7f7`](https://github.com/Runnable/ponos/commit/053f7f7dbe5cddf007b504d560a321baa55b7210) `chore(package): update flow-bin to version 0.26.0`
- [`5bbe224`](https://github.com/Runnable/ponos/commit/5bbe224f6e9519827361b527101ea40c4effd221) `Merge pull request #49 from Runnable/codeclimate-fixes`
- [`110a083`](https://github.com/Runnable/ponos/commit/110a083db8e5c60f2c876ff8ec967c8123cb1eef) `add codeclimate config`
- [`4d820c6`](https://github.com/Runnable/ponos/commit/4d820c60d02ba0b17ec4e0485c1328770adf64ed) `3.1.0`
- [`4eb2cc7`](https://github.com/Runnable/ponos/commit/4eb2cc7ed447d94234df29189782524f99ebbecc) `Merge pull request #48 from Runnable/prefetch`
- [`0bed566`](https://github.com/Runnable/ponos/commit/0bed5667489c2e08ad72d7101b83ae78c9fc9345) `add ability to set prefetch for channel`
- [`6f5dbbc`](https://github.com/Runnable/ponos/commit/6f5dbbc23ab4342691c39113f7cf58deea428578) `Merge pull request #47 from Runnable/greenkeeper-mocha-2.5.0`
- [`f697701`](https://github.com/Runnable/ponos/commit/f697701b0f9d918301949a2946af9899c31e8f38) `mocha@2.5.1`
- [`b8687d9`](https://github.com/Runnable/ponos/commit/b8687d9150d2ea767964f6a17e16288b5f51339d) `chore(package): update mocha to version 2.5.0`
- [`9f23436`](https://github.com/Runnable/ponos/commit/9f2343659902adf7a9c34e62eda7caab43c35d12) `changelog@v3.0.2`

There are 115 commits in total. See the [full diff](https://github.com/Runnable/ponos/compare/18adf3aa52bdc93b46971c3b8b69114fcbf40b34...bc88408c43bf9ee440ce26894e649dc90da138bf).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
