### PR TITLE
Update instance.container.health-check.failed.js

### DIFF
--- a/lib/workers/instance.container.health-check.failed.js
+++ b/lib/workers/instance.container.health-check.failed.js
@@ -9,7 +9,7 @@ module.exports.jobSchema = Joi.object({
   host: Joi.string().required(),
   id: Joi.string().required(),
   tid: Joi.string()
-}).required().label('DockerContainerPoll job')
+}).required().label('InstanceContainerHealthCheckFailed job')
 
 module.exports.task = (job) => {
   return Promise


### PR DESCRIPTION
Do not proceed when `event.status` is not allowed. Cut out all the jobs on the validation stage.
Prevent errors like this: https://rollbar.com/Runnable-2/docker-listener/items/597/occurrences/16108923377/
