### PR TITLE
add better validation

### DIFF
--- a/lib/docker-utils.js
+++ b/lib/docker-utils.js
@@ -74,9 +74,8 @@ module.exports._handleInspectError = (host, err, log) => {
         log.trace('_handleInspectError - host does not exist')
         const fatalErr = new WorkerStopError(
           'host does not exist',
-          { host: host }
+          { host: host }, { level: 'info' }
         )
-        fatalErr.report = false
         throw fatalErr
       }
 

--- a/lib/workers/docker.event.publish.js
+++ b/lib/workers/docker.event.publish.js
@@ -22,7 +22,7 @@ module.exports.jobSchema = Joi.object({
   ip: Joi.string().required(),
   needsInspect: Joi.boolean().required(),
   org: Joi.string().required(),
-  status: Joi.string().required(),
+  status: Joi.string().only('create', 'start', 'die', 'engine_connect').required(),
   tags: Joi.string().required(),
   time: Joi.number().required(),
   uuid: Joi.string().required(),


### PR DESCRIPTION
Prevent publish job to proceed when `event.status` is invalid. Job would be dismissed on the validation stage.
