### PR TITLE
Rename event

### DIFF
--- a/lib/docker-utils.js
+++ b/lib/docker-utils.js
@@ -73,7 +73,7 @@ module.exports._handleInspectError = (host, err, log) => {
     })
     .then((exists) => {
       if (!exists) {
-        rabbitmq.publishEvent('on-dock-unhealthy', {
+        rabbitmq.publishEvent('dock.lost', {
           host: host
         })
         log.trace('_handleInspectError - host does not exist')

--- a/test/unit/docker-utils.js
+++ b/test/unit/docker-utils.js
@@ -138,7 +138,7 @@ describe('docker utils unit test', () => {
       dockerUtils._handleInspectError('host', testErr, logStub).asCallback((err) => {
         expect(err).to.be.an.instanceOf(WorkerStopError)
         sinon.assert.calledOnce(rabbitmq.publishEvent)
-        sinon.assert.calledWith(rabbitmq.publishEvent, 'on-dock-unhealthy', {
+        sinon.assert.calledWith(rabbitmq.publishEvent, 'dock.lost', {
           host: 'host'
         })
         done()


### PR DESCRIPTION
We don't really have `on-dock-unhealthy` event. Code was wrong since it wasn't event.
`dock.lost` is the new event.
