### PR TITLE
Fix dock.lost publishing

### DIFF
--- a/lib/docker-utils.js
+++ b/lib/docker-utils.js
@@ -38,21 +38,29 @@ module.exports.testEvent = function (dockerClient) {
   })
 }
 
+module.exports.toDockerHost = (url) => {
+  return url.replace('http://', '')
+}
+
+module.exports.toDockerUrl = (host) => {
+  const ensuredHost = module.exports.toDockerHost(host)
+  return 'http://' + ensuredHost
+}
 /**
  * handles inspect errors.
  * if 404 call task fatal
  *   else check if the dock still exists
  *   throw task fatal if it does not
- * @param  {String} host target host for inspect
+ * @param  {String} host target host for inspect in the format 10.0.0.1:4242
  * @param  {Error}  err  error from docker inspect
  * @param  {Object} log  current logger
  * @return {Promise}
  * @resolve {undefined}
  * @reject {WorkerStopError} If 404 or dock does not exist
- *         {Error}          If error unknown
- * @throws {WorkerStopError} If 404 or dock does not exist
+ *         {Error}           If error unknown
  */
 module.exports._handleInspectError = (host, err, log) => {
+  const dockerHost = module.exports.toDockerHost(host)
   if (err.statusCode === 404) {
     // container is not there anymore. Exit
     const fatalErr = new WorkerStopError(
@@ -65,7 +73,7 @@ module.exports._handleInspectError = (host, err, log) => {
   log.error({ err: err }, '_handleInspectError - inspect error')
   // check to see if host still exist before retrying
   const swarm = new Swarm(process.env.SWARM_HOST)
-  return swarm.swarmHostExistsAsync(host)
+  return swarm.swarmHostExistsAsync(dockerHost)
     .catch((hostErr) => {
       log.trace({ err: hostErr }, '_handleInspectError - swarmHostExists error')
       // if above errors, throw original error
@@ -74,7 +82,7 @@ module.exports._handleInspectError = (host, err, log) => {
     .then((exists) => {
       if (!exists) {
         rabbitmq.publishEvent('dock.lost', {
-          host: host
+          host: module.exports.toDockerUrl(dockerHost)
         })
         log.trace('_handleInspectError - host does not exist')
         const fatalErr = new WorkerStopError(

--- a/lib/docker-utils.js
+++ b/lib/docker-utils.js
@@ -46,6 +46,7 @@ module.exports.toDockerUrl = (host) => {
   const ensuredHost = module.exports.toDockerHost(host)
   return 'http://' + ensuredHost
 }
+
 /**
  * handles inspect errors.
  * if 404 call task fatal

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -147,7 +147,7 @@ module.exports = class EventListener {
     event.dockerPort = event.Host.split(':')[1]
     // keep tags for legacy reasons
     event.tags = event.org
-    const dockerUrl = 'http://' + event.Host
+    const dockerUrl = dockerUtils.toDockerUrl(event.Host)
 
     // we expose one value as two results for compatibility reasons
     event.host = dockerUrl

--- a/lib/rabbitmq.js
+++ b/lib/rabbitmq.js
@@ -3,6 +3,7 @@ require('loadenv')()
 
 const RabbitMQ = require('ponos/lib/rabbitmq')
 const publisher = new RabbitMQ({ name: process.env.APP_NAME })
+const dockerUtils = require('./docker-utils')
 const logger = require('./logger')()
 
 module.exports = publisher
@@ -31,9 +32,8 @@ publisher.createConnectedJob = function (type, host, org) {
   })
   log.info('call')
   // we need to send tags for backwards compatibility
-  // also host needs to have http://
   publisher.publishEvent(type + '.events-stream.connected', {
-    host: 'http://' + host,
+    host: dockerUtils.toDockerUrl(host),
     org: org,
     tags: org
   })
@@ -52,9 +52,8 @@ publisher.createDisconnectedJob = function (host, org) {
   })
   log.info('call')
   // we need to send tags for backwards compatibility
-  // also host needs to have http://
   publisher.publishEvent('docker.events-stream.disconnected', {
-    host: 'http://' + host,
+    host: dockerUtils.toDockerUrl(host),
     org: org
   })
 }

--- a/lib/workers/container.state.poll.js
+++ b/lib/workers/container.state.poll.js
@@ -1,7 +1,7 @@
 'use strict'
 require('loadenv')()
 
-const Joi = require('joi')
+const joi = require('joi')
 const Promise = require('bluebird')
 
 const dockerUtils = require('../docker-utils')
@@ -9,10 +9,10 @@ const Docker = require('../docker')
 const log = require('../logger')()
 const rabbitmq = require('../rabbitmq')
 
-module.exports.jobSchema = Joi.object({
-  host: Joi.string().required(),
-  id: Joi.string().required(),
-  tid: Joi.string()
+module.exports.jobSchema = joi.object({
+  host: joi.string().uri({ scheme: 'http' }).required(),
+  id: joi.string().required(),
+  tid: joi.string()
 }).unknown().required().label('DockerContainerPoll job')
 
 module.exports.task = (job) => {

--- a/lib/workers/docker.event.publish.js
+++ b/lib/workers/docker.event.publish.js
@@ -46,7 +46,7 @@ const DockerEventPublish = (job) => {
           return job
         })
         .catch((err) => {
-          return dockerUtils._handleInspectError(job.Host, err, log)
+          return dockerUtils._handleInspectError(job.host, err, log)
         })
     })
     .then((event) => {

--- a/lib/workers/instance.container.health-check.failed.js
+++ b/lib/workers/instance.container.health-check.failed.js
@@ -1,14 +1,14 @@
 'use strict'
 require('loadenv')()
 
-const Joi = require('joi')
+const joi = require('joi')
 const Promise = require('bluebird')
 const rabbitmq = require('../rabbitmq')
 
-module.exports.jobSchema = Joi.object({
-  host: Joi.string().required(),
-  id: Joi.string().required(),
-  tid: Joi.string()
+module.exports.jobSchema = joi.object({
+  host: joi.string().uri({ scheme: 'http' }).required(),
+  id: joi.string().required(),
+  tid: joi.string()
 }).required().label('InstanceContainerHealthCheckFailed job')
 
 module.exports.task = (job) => {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "homepage": "https://github.com/CodeNow/docker-listener",
   "dependencies": {
     "101": "^1.5.0",
-    "bluebird": "^3.3.4",
+    "@runnable/loki": "^3.1.0",
+    "bluebird": "3.4.3",
     "bunyan": "^1.7.1",
     "callsite": "^1.0.0",
     "continuation-local-storage": "^3.1.7",
@@ -45,10 +46,10 @@
     "joi": "^9.0.4",
     "keypather": "^1.10.2",
     "loadenv": "^2.1.0",
-    "@runnable/loki": "^3.1.0",
     "monitor-dog": "^1.5.0",
     "node-uuid": "^1.4.7",
-    "ponos": "^4.6.0"
+    "ponos": "^4.6.0",
+    "sinon-as-promised": "^4.0.2"
   },
   "devDependencies": {
     "code": "^2.1.0",

--- a/test/unit/docker-utils.js
+++ b/test/unit/docker-utils.js
@@ -16,7 +16,6 @@ const dockerUtils = require('../../lib/docker-utils')
 const rabbitmq = require('../../lib/rabbitmq')
 const Swarm = require('../../lib/swarm')
 
-
 const lab = exports.lab = Lab.script()
 
 const afterEach = lab.afterEach
@@ -144,5 +143,29 @@ describe('docker utils unit test', () => {
         done()
       })
     })
-  }) // end _handleInspectError
+  })
+
+  describe('toDockerHost', () => {
+    it('should convert url to host', (done) => {
+      expect(dockerUtils.toDockerHost('http://10.0.0.1:4242')).to.equal('10.0.0.1:4242')
+      done()
+    })
+
+    it('should return same valid host', (done) => {
+      expect(dockerUtils.toDockerHost('10.0.0.1:4242')).to.equal('10.0.0.1:4242')
+      done()
+    })
+  })
+
+  describe('toDockerUrl', () => {
+    it('should convert host to url', (done) => {
+      expect(dockerUtils.toDockerUrl('10.0.0.1:4242')).to.equal('http://10.0.0.1:4242')
+      done()
+    })
+
+    it('should return same valid url', (done) => {
+      expect(dockerUtils.toDockerUrl('http://10.0.0.1:4242')).to.equal('http://10.0.0.1:4242')
+      done()
+    })
+  })
 })

--- a/test/unit/docker-utils.js
+++ b/test/unit/docker-utils.js
@@ -139,7 +139,7 @@ describe('docker utils unit test', () => {
         expect(err).to.be.an.instanceOf(WorkerStopError)
         sinon.assert.calledOnce(rabbitmq.publishEvent)
         sinon.assert.calledWith(rabbitmq.publishEvent, 'dock.lost', {
-          host: 'host'
+          host: 'http://host'
         })
         done()
       })

--- a/test/unit/worker/docker.event.publish.js
+++ b/test/unit/worker/docker.event.publish.js
@@ -166,7 +166,7 @@ describe('docker event publish', () => {
         if (err) { return done(err) }
 
         sinon.assert.calledOnce(dockerUtils._handleInspectError)
-        sinon.assert.calledWith(dockerUtils._handleInspectError, testJob.Host, testError, sinon.match.object)
+        sinon.assert.calledWith(dockerUtils._handleInspectError, testJob.host, testError, sinon.match.object)
         done()
       })
     })


### PR DESCRIPTION
Docker listener was publishing invalid job in one case. `job.host` was missing `http://`.

https://rollbar.com/Runnable-2/palantiri/items/27/
https://runnable.atlassian.net/browse/SAN-4865
