### PR TITLE
Resolve cyclic dep & fix SAN-4888

### DIFF
--- a/configs/.env
+++ b/configs/.env
@@ -1,11 +1,11 @@
+APP_NAME=docker.listener
+DEBUG=swarmerode
+DOCKER_TIMEOUT=60000
 EVENT_TIMEOUT_MS=5000
 IMAGE_BLACKLIST=weaveworks/weaveexec,runnable/libra
 IMAGE_INSPECT_LIST=localhost,registry.runnable.com
 LOG_LEVEL_STDOUT=trace
 PORT=3000
-DEBUG=swarmerode
-
-APP_NAME=docker.listener
 
 # for monitor dog
 MONITOR_INTERVAL=60000

--- a/configs/.env
+++ b/configs/.env
@@ -1,6 +1,6 @@
 APP_NAME=docker.listener
 DEBUG=swarmerode
-DOCKER_TIMEOUT=60000
+DOCKER_TIMEOUT=5000
 EVENT_TIMEOUT_MS=5000
 IMAGE_BLACKLIST=weaveworks/weaveexec,runnable/libra
 IMAGE_INSPECT_LIST=localhost,registry.runnable.com

--- a/lib/docker-utils.js
+++ b/lib/docker-utils.js
@@ -3,18 +3,20 @@
 const isEmpty = require('101/is-empty')
 const WorkerStopError = require('error-cat/errors/worker-stop-error')
 const log = require('./logger')()
+const Docker = require('./docker')
 const Swarm = require('./swarm')
+const rabbitmq = require('./rabbitmq')
 
-/**
- * Do docker top on a random container. All errors would be catched and logged
- * without propagation
- * This should emit the `top` event.
- * We ignore errors since we will restart if event failed
- * @param  {Object} dockerClient instance of Docker or Swarm client (loki)
- * @returns promise
- * @resolves (null) when test complete
- */
 module.exports = class Utils {
+  /**
+   * Do docker top on a random container. All errors would be catched and logged
+   * without propagation
+   * This should emit the `top` event.
+   * We ignore errors since we will restart if event failed
+   * @param  {Object} dockerClient instance of Docker or Swarm client (loki)
+   * @returns promise
+   * @resolves (null) when test complete
+   */
   static testEvent (dockerClient) {
     log.info('test-event')
     return dockerClient.listContainersAsync({
@@ -38,15 +40,6 @@ module.exports = class Utils {
     })
   }
 
-  static toDockerHost (url) {
-    return url.replace('http://', '')
-  }
-
-  static toDockerUrl (host) {
-    const ensuredHost = Utils.toDockerHost(host)
-    return 'http://' + ensuredHost
-  }
-
   /**
    * handles inspect errors.
    * if 404 call task fatal
@@ -61,7 +54,7 @@ module.exports = class Utils {
    *         {Error}           If error unknown
    */
   static _handleInspectError (host, err, log) {
-    const dockerHost = Utils.toDockerHost(host)
+    const dockerHost = Docker.toDockerHost(host)
     if (err.statusCode === 404) {
       // container is not there anymore. Exit
       const fatalErr = new WorkerStopError(
@@ -82,10 +75,8 @@ module.exports = class Utils {
       })
       .then((exists) => {
         if (!exists) {
-          // TODO: cyclic dependency
-          const rabbitmq = require('./rabbitmq')
           rabbitmq.publishEvent('dock.lost', {
-            host: Utils.toDockerUrl(dockerHost)
+            host: Docker.toDockerUrl(dockerHost)
           })
           log.trace('_handleInspectError - host does not exist')
           const fatalErr = new WorkerStopError(

--- a/lib/docker-utils.js
+++ b/lib/docker-utils.js
@@ -53,7 +53,7 @@ module.exports = class Utils {
    * @reject {WorkerStopError} If 404 or dock does not exist
    *         {Error}           If error unknown
    */
-  static _handleInspectError (host, err, log) {
+  static handleInspectError (host, err, log) {
     const dockerHost = Docker.toDockerHost(host)
     if (err.statusCode === 404) {
       // container is not there anymore. Exit
@@ -61,15 +61,15 @@ module.exports = class Utils {
         err.message,
         { originalError: err }, { level: 'info' }
       )
-      log.trace({ err: err }, '_handleInspectError - container not found')
+      log.trace({ err: err }, 'handleInspectError - container not found')
       throw fatalErr
     }
-    log.error({ err: err }, '_handleInspectError - inspect error')
+    log.error({ err: err }, 'handleInspectError - inspect error')
     // check to see if host still exist before retrying
     const swarm = new Swarm(process.env.SWARM_HOST)
     return swarm.swarmHostExistsAsync(dockerHost)
       .catch((hostErr) => {
-        log.trace({ err: hostErr }, '_handleInspectError - swarmHostExists error')
+        log.trace({ err: hostErr }, 'handleInspectError - swarmHostExists error')
         // if above errors, throw original error
         throw err
       })
@@ -78,7 +78,7 @@ module.exports = class Utils {
           rabbitmq.publishEvent('dock.lost', {
             host: Docker.toDockerUrl(dockerHost)
           })
-          log.trace('_handleInspectError - host does not exist')
+          log.trace('handleInspectError - host does not exist')
           const fatalErr = new WorkerStopError(
             'host does not exist',
             { host: host }, { level: 'info' }

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -2,8 +2,6 @@
 require('loadenv')()
 
 const DockerClient = require('@runnable/loki').Docker
-
-const dockerUtils = require('./docker-utils')
 const logger = require('./logger')()
 
 module.exports = class Docker extends DockerClient {
@@ -13,7 +11,16 @@ module.exports = class Docker extends DockerClient {
    * @return {Docker}      Docker instance
    */
   constructor (host) {
-    const dockerHost = 'https://' + dockerUtils.toDockerHost(host)
+    const dockerHost = 'https://' + Docker.toDockerHost(host)
     super({ host: dockerHost, log: logger })
+  }
+
+  static toDockerHost (url) {
+    return url.replace('http://', '')
+  }
+
+  static toDockerUrl (host) {
+    const ensuredHost = Docker.toDockerHost(host)
+    return 'http://' + ensuredHost
   }
 }

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -147,7 +147,7 @@ module.exports = class EventListener {
     event.dockerPort = event.Host.split(':')[1]
     // keep tags for legacy reasons
     event.tags = event.org
-    const dockerUrl = dockerUtils.toDockerUrl(event.Host)
+    const dockerUrl = Docker.toDockerUrl(event.Host)
 
     // we expose one value as two results for compatibility reasons
     event.host = dockerUrl

--- a/lib/rabbitmq.js
+++ b/lib/rabbitmq.js
@@ -2,7 +2,7 @@
 require('loadenv')()
 
 const RabbitMQ = require('ponos/lib/rabbitmq')
-const dockerUtils = require('./docker-utils')
+const Docker = require('./docker')
 const logger = require('./logger')()
 
 class Publisher extends RabbitMQ {
@@ -35,7 +35,7 @@ class Publisher extends RabbitMQ {
     log.info('call')
     // we need to send tags for backwards compatibility
     this.publishEvent(type + '.events-stream.connected', {
-      host: dockerUtils.toDockerUrl(host),
+      host: Docker.toDockerUrl(host),
       org: org,
       tags: org
     })
@@ -55,7 +55,7 @@ class Publisher extends RabbitMQ {
     log.info('call')
     // we need to send tags for backwards compatibility
     this.publishEvent('docker.events-stream.disconnected', {
-      host: dockerUtils.toDockerUrl(host),
+      host: Docker.toDockerUrl(host),
       org: org
     })
   }

--- a/lib/workers/container.state.poll.js
+++ b/lib/workers/container.state.poll.js
@@ -26,7 +26,7 @@ module.exports.task = (job) => {
           return job
         })
         .catch((err) => {
-          return dockerUtils._handleInspectError(job.host, err, log)
+          return dockerUtils.handleInspectError(job.host, err, log)
         })
     })
     .then((event) => {

--- a/lib/workers/container.state.poll.js
+++ b/lib/workers/container.state.poll.js
@@ -9,6 +9,8 @@ const Docker = require('../docker')
 const log = require('../logger')()
 const rabbitmq = require('../rabbitmq')
 
+module.exports.maxNumRetries = 5
+
 module.exports.jobSchema = joi.object({
   host: joi.string().uri({ scheme: 'http' }).required(),
   id: joi.string().required(),

--- a/lib/workers/docker.event.publish.js
+++ b/lib/workers/docker.event.publish.js
@@ -74,7 +74,7 @@ const DockerEventPublish = (job) => {
       const docker = new Docker(job.Host)
       return docker.inspectContainerAsync(job.id)
         .catch((err) => {
-          return dockerUtils._handleInspectError(job.host, err, log)
+          return dockerUtils.handleInspectError(job.host, err, log)
         })
         .then((inspectData) => {
           return Promise.fromCallback((cb) => {

--- a/test/unit/docker-utils.js
+++ b/test/unit/docker-utils.js
@@ -85,7 +85,7 @@ describe('docker utils unit test', () => {
     })
   }) // end testEvent
 
-  describe('_handleInspectError', function () {
+  describe('handleInspectError', function () {
     const logStub = {
       trace: sinon.spy(),
       error: sinon.spy()
@@ -106,7 +106,7 @@ describe('docker utils unit test', () => {
       const error = new Error('Docker error')
       error.statusCode = 404
       expect(() => {
-        dockerUtils._handleInspectError('test', error, logStub)
+        dockerUtils.handleInspectError('test', error, logStub)
       }).to.throw(WorkerStopError, 'Docker error')
       done()
     })
@@ -115,7 +115,7 @@ describe('docker utils unit test', () => {
       const testErr = new Error('bully')
       testErr.statusCode = 500
       Swarm.prototype.swarmHostExistsAsync.returns(Promise.reject('reject'))
-      dockerUtils._handleInspectError('host', testErr, logStub).asCallback((err) => {
+      dockerUtils.handleInspectError('host', testErr, logStub).asCallback((err) => {
         expect(err).to.equal(testErr)
         done()
       })
@@ -124,7 +124,7 @@ describe('docker utils unit test', () => {
     it('should throw original error if host exists', (done) => {
       const testErr = new Error('ruffian')
       Swarm.prototype.swarmHostExistsAsync.returns(Promise.resolve(true))
-      dockerUtils._handleInspectError('host', testErr, logStub).asCallback((err) => {
+      dockerUtils.handleInspectError('host', testErr, logStub).asCallback((err) => {
         expect(err).to.equal(testErr)
         sinon.assert.notCalled(rabbitmq.publishEvent)
         done()
@@ -134,7 +134,7 @@ describe('docker utils unit test', () => {
     it('should throw WorkerStopError error if host !exists', (done) => {
       const testErr = new Error('hooligan')
       Swarm.prototype.swarmHostExistsAsync.returns(Promise.resolve(false))
-      dockerUtils._handleInspectError('host', testErr, logStub).asCallback((err) => {
+      dockerUtils.handleInspectError('host', testErr, logStub).asCallback((err) => {
         expect(err).to.be.an.instanceOf(WorkerStopError)
         sinon.assert.calledOnce(rabbitmq.publishEvent)
         sinon.assert.calledWith(rabbitmq.publishEvent, 'dock.lost', {

--- a/test/unit/docker-utils.js
+++ b/test/unit/docker-utils.js
@@ -144,28 +144,4 @@ describe('docker utils unit test', () => {
       })
     })
   })
-
-  describe('toDockerHost', () => {
-    it('should convert url to host', (done) => {
-      expect(dockerUtils.toDockerHost('http://10.0.0.1:4242')).to.equal('10.0.0.1:4242')
-      done()
-    })
-
-    it('should return same valid host', (done) => {
-      expect(dockerUtils.toDockerHost('10.0.0.1:4242')).to.equal('10.0.0.1:4242')
-      done()
-    })
-  })
-
-  describe('toDockerUrl', () => {
-    it('should convert host to url', (done) => {
-      expect(dockerUtils.toDockerUrl('10.0.0.1:4242')).to.equal('http://10.0.0.1:4242')
-      done()
-    })
-
-    it('should return same valid url', (done) => {
-      expect(dockerUtils.toDockerUrl('http://10.0.0.1:4242')).to.equal('http://10.0.0.1:4242')
-      done()
-    })
-  })
 })

--- a/test/unit/docker.js
+++ b/test/unit/docker.js
@@ -1,0 +1,39 @@
+'use strict'
+
+require('loadenv')()
+const Code = require('code')
+const Lab = require('lab')
+
+const Docker = require('../../lib/docker')
+
+const lab = exports.lab = Lab.script()
+
+const describe = lab.experiment
+const it = lab.test
+const expect = Code.expect
+
+describe('docker unit test', () => {
+  describe('toDockerHost', () => {
+    it('should convert url to host', (done) => {
+      expect(Docker.toDockerHost('http://10.0.0.1:4242')).to.equal('10.0.0.1:4242')
+      done()
+    })
+
+    it('should return same valid host', (done) => {
+      expect(Docker.toDockerHost('10.0.0.1:4242')).to.equal('10.0.0.1:4242')
+      done()
+    })
+  })
+
+  describe('toDockerUrl', () => {
+    it('should convert host to url', (done) => {
+      expect(Docker.toDockerUrl('10.0.0.1:4242')).to.equal('http://10.0.0.1:4242')
+      done()
+    })
+
+    it('should return same valid url', (done) => {
+      expect(Docker.toDockerUrl('http://10.0.0.1:4242')).to.equal('http://10.0.0.1:4242')
+      done()
+    })
+  })
+})

--- a/test/unit/worker/container.state.poll.js
+++ b/test/unit/worker/container.state.poll.js
@@ -36,14 +36,14 @@ describe('docker container poll', () => {
   describe('worker', () => {
     beforeEach((done) => {
       sinon.stub(DockerClient.prototype, 'inspectContainerAsync')
-      sinon.stub(dockerUtils, '_handleInspectError')
+      sinon.stub(dockerUtils, 'handleInspectError')
       sinon.stub(rabbitmq, 'publishEvent')
       done()
     })
 
     afterEach((done) => {
       DockerClient.prototype.inspectContainerAsync.restore()
-      dockerUtils._handleInspectError.restore()
+      dockerUtils.handleInspectError.restore()
       rabbitmq.publishEvent.restore()
       done()
     })
@@ -64,8 +64,8 @@ describe('docker container poll', () => {
       DockerClient.prototype.inspectContainerAsync.rejects(testError)
       ContainerStatePoll(testJob).asCallback((err) => {
         if (err) { return done(err) }
-        sinon.assert.calledOnce(dockerUtils._handleInspectError)
-        sinon.assert.calledWith(dockerUtils._handleInspectError, testJob.host, testError, sinon.match.object)
+        sinon.assert.calledOnce(dockerUtils.handleInspectError)
+        sinon.assert.calledWith(dockerUtils.handleInspectError, testJob.host, testError, sinon.match.object)
         done()
       })
     })

--- a/test/unit/worker/docker.event.publish.js
+++ b/test/unit/worker/docker.event.publish.js
@@ -103,7 +103,7 @@ describe('docker event publish', () => {
   describe('worker', () => {
     beforeEach((done) => {
       sinon.stub(DockerClient.prototype, 'inspectContainerAsync')
-      sinon.stub(dockerUtils, '_handleInspectError')
+      sinon.stub(dockerUtils, 'handleInspectError')
       sinon.stub(DockerEventPublish, '_handlePublish')
       sinon.stub(sinceMap, 'set')
       done()
@@ -111,7 +111,7 @@ describe('docker event publish', () => {
 
     afterEach((done) => {
       DockerClient.prototype.inspectContainerAsync.restore()
-      dockerUtils._handleInspectError.restore()
+      dockerUtils.handleInspectError.restore()
       DockerEventPublish._handlePublish.restore()
       sinceMap.set.restore()
       done()
@@ -230,8 +230,8 @@ describe('docker event publish', () => {
       DockerEventPublish(testJob).asCallback((err) => {
         if (err) { return done(err) }
 
-        sinon.assert.calledOnce(dockerUtils._handleInspectError)
-        sinon.assert.calledWith(dockerUtils._handleInspectError, testJob.host, testError, sinon.match.object)
+        sinon.assert.calledOnce(dockerUtils.handleInspectError)
+        sinon.assert.calledWith(dockerUtils.handleInspectError, testJob.host, testError, sinon.match.object)
         done()
       })
     })


### PR DESCRIPTION
- resolve cyclic dependency in a more clear way
- add docker timeout that should help with `docker.inspect` calls during `container.state.poll` error. See https://sandboxes.loggly.com/search#terms=%22container.state.poll%22&from=2016-09-01T18%3A45%3A42.940Z&until=2016-09-01T21%3A00%3A47.096Z&source_group=&filter=json.name%3Bdocker.listener . In this case a lot of similar jobs were published but `docker.inspect` took a long time to fail that causes jobs to pile up
- add max number retries to container.state.poll worker. It seems like swarm was unreachable https://sandboxes.loggly.com/search#terms=%22container.state.poll%22&from=2016-09-01T19%3A10%3A19.593Z&until=2016-09-01T20%3A15%3A14.704Z&source_group=&filter=json.name%3Bdocker.listener and that causes job to repeat itself. We need to do just 5 retries and than job would be enqueued again later by khronos
