### PR TITLE
Timeout is optional and only specified for docker.inspect

### DIFF
--- a/configs/.env
+++ b/configs/.env
@@ -1,5 +1,6 @@
 APP_NAME=docker.listener
 DEBUG=swarmerode
+DOCKER_INSPECT_TIMEOUT=5000
 EVENT_TIMEOUT_MS=5000
 IMAGE_BLACKLIST=weaveworks/weaveexec,runnable/libra
 IMAGE_INSPECT_LIST=localhost,registry.runnable.com

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -8,11 +8,19 @@ module.exports = class Docker extends DockerClient {
   /**
    * creates docker class
    * @param  {String} host docker host format: 10.0.0.0:4242
+   * @param  {Number} timeout optional timeout
    * @return {Docker}      Docker instance
    */
-  constructor (host) {
+  constructor (host, timeout) {
     const dockerHost = 'https://' + Docker.toDockerHost(host)
-    super({ host: dockerHost, log: logger })
+    const opts = {
+      host: dockerHost,
+      log: logger
+    }
+    if (timeout) {
+      opts.timeout = timeout
+    }
+    super(opts)
   }
 
   static toDockerHost (url) {

--- a/lib/workers/container.state.poll.js
+++ b/lib/workers/container.state.poll.js
@@ -14,7 +14,7 @@ module.exports.jobSchema = schemas.containerStatePoll
 module.exports.task = (job) => {
   return Promise
     .try((cb) => {
-      const docker = new Docker(job.host)
+      const docker = new Docker(job.host, process.env.DOCKER_INSPECT_TIMEOUT)
       return docker.inspectContainerAsync(job.id)
         .then((inspectData) => {
           job.inspectData = inspectData

--- a/test/unit/docker.js
+++ b/test/unit/docker.js
@@ -13,6 +13,26 @@ const it = lab.test
 const expect = Code.expect
 
 describe('docker unit test', () => {
+  describe('constructor', () => {
+    it('should add prootocol to the host', (done) => {
+      const docker = new Docker('10.0.0.1:4242')
+      expect(docker.client.modem.host).to.equal('https://10.0.0.1:4242')
+      done()
+    })
+
+    it('should skip timeout if undefined', (done) => {
+      const docker = new Docker('10.0.0.1:4242')
+      expect(docker.client.modem.timeout).to.be.undefined()
+      done()
+    })
+
+    it('should set timeout if provided', (done) => {
+      const timeout = 3500
+      const docker = new Docker('10.0.0.1:4242', timeout)
+      expect(docker.client.modem.timeout).to.equal(timeout)
+      done()
+    })
+  })
   describe('toDockerHost', () => {
     it('should convert url to host', (done) => {
       expect(Docker.toDockerHost('http://10.0.0.1:4242')).to.equal('10.0.0.1:4242')


### PR DESCRIPTION
Provide optional `docker` timeout.
Used only by `docker inspect` call. This shouldn't affect stream calls.
