### PR TITLE
Fix issue with publishing dock.lost

### DIFF
--- a/lib/rabbitmq.js
+++ b/lib/rabbitmq.js
@@ -10,9 +10,17 @@ const logger = require('./logger')()
 
 class Publisher extends RabbitMQ {
   constructor () {
+    const log = logger.child({
+      module: 'publisher'
+    })
     super({
       name: process.env.APP_NAME,
-      events: [{
+      log: log,
+      events: [
+      {
+        name: 'dock.lost',
+        jobSchema: schemas.dockLost
+      }, {
         name: 'docker.events-stream.disconnected',
         jobSchema: schemas.eventsStreamDisconnected
       }, {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -2,6 +2,10 @@
 
 const joi = require('joi')
 
+module.exports.dockLost = joi.object({
+  host: joi.string().required()
+}).unknown().required()
+
 module.exports.containerStatePoll = joi.object({
   host: joi.string().required(),
   id: joi.string().required(),


### PR DESCRIPTION
While looking why `network-canary`  failed I found that we failed to publish `dock.lost` event from docker listener: https://sandboxes.loggly.com/search#terms=%22dock.lost%22&from=2016-09-09T21%3A48%3A32.248Z&until=2016-09-16T21%3A48%3A32.248Z&source_group=

Fix this issue. Also provide logger for rabbitmq publishing.
