### PR TITLE
Pass github org id

### DIFF
--- a/lib/docker-utils.js
+++ b/lib/docker-utils.js
@@ -77,7 +77,8 @@ module.exports = class Utils {
       .then((exists) => {
         if (!exists) {
           rabbitmq.publishEvent('dock.lost', {
-            host: Docker.toDockerUrl(dockerHost)
+            host: Docker.toDockerUrl(dockerHost),
+            githubOrgId: githubOrgId
           })
           log.trace('handleInspectError - host does not exist')
           const fatalErr = new WorkerStopError(

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -3,7 +3,9 @@
 const joi = require('joi')
 
 module.exports.dockLost = joi.object({
-  host: joi.string().required()
+  host: joi.string().required(),
+  // TODO make it required after we fix containerStatePoll
+  githubOrgId: joi.number()
 }).unknown().required()
 
 module.exports.containerStatePoll = joi.object({

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -3,7 +3,7 @@
 const joi = require('joi')
 
 module.exports.dockLost = joi.object({
-  host: joi.string().required(),
+  host: joi.string().uri({ scheme: 'http' }).required(),
   // TODO make it required after we fix containerStatePoll
   githubOrgId: joi.number()
 }).unknown().required()

--- a/test/unit/docker-utils.js
+++ b/test/unit/docker-utils.js
@@ -134,11 +134,12 @@ describe('docker utils unit test', () => {
     it('should throw WorkerStopError error if host !exists', (done) => {
       const testErr = new Error('hooligan')
       Swarm.prototype.swarmHostExistsAsync.returns(Promise.resolve(false))
-      dockerUtils.handleInspectError('host', null, testErr, logStub).asCallback((err) => {
+      dockerUtils.handleInspectError('host', 123, testErr, logStub).asCallback((err) => {
         expect(err).to.be.an.instanceOf(WorkerStopError)
         sinon.assert.calledOnce(rabbitmq.publishEvent)
         sinon.assert.calledWith(rabbitmq.publishEvent, 'dock.lost', {
-          host: 'http://host'
+          host: 'http://host',
+          githubOrgId: 123
         })
         done()
       })


### PR DESCRIPTION
dock.lost should pass `githubOrgId`. 
Right now it's optional because in one case it depends on the job emitted by khronos and that job doesn't have orgId yet
