### PR TITLE
Emit additional events per type

### DIFF
--- a/lib/rabbitmq.js
+++ b/lib/rabbitmq.js
@@ -32,10 +32,28 @@ class Publisher extends RabbitMQ {
         name: 'container.life-cycle.created',
         jobSchema: schemas.containerLifeCycle
       }, {
+        name: 'image-builder.container.life-cycle.created',
+        jobSchema: schemas.containerLifeCycle
+      }, {
+        name: 'user-container.container.life-cycle.created',
+        jobSchema: schemas.containerLifeCycle
+      }, {
         name: 'container.life-cycle.started',
         jobSchema: schemas.containerLifeCycle
       }, {
+        name: 'image-builder.container.life-cycle.started',
+        jobSchema: schemas.containerLifeCycle
+      }, {
+        name: 'user-container.container.life-cycle.started',
+        jobSchema: schemas.containerLifeCycle
+      }, {
         name: 'container.life-cycle.died',
+        jobSchema: schemas.containerLifeCycle
+      }, {
+        name: 'image-builder.container.life-cycle.died',
+        jobSchema: schemas.containerLifeCycle
+      }, {
+        name: 'user-container.container.life-cycle.died',
         jobSchema: schemas.containerLifeCycle
       }, {
         name: 'container.state.polled',

--- a/lib/workers/docker.event.publish.js
+++ b/lib/workers/docker.event.publish.js
@@ -84,6 +84,13 @@ const DockerEventPublish = (job) => {
     })
 }
 
+DockerEventPublish._publishEvent = (eventName, event) => {
+  const type = keypather.get(event, 'inspectData.Config.Labels.type')
+  rabbitmq.publishEvent(eventName, event)
+  if (type === 'user-container' || type === 'image-builder') {
+    rabbitmq.publishEvent(`${type}.${eventName}`, event)
+  }
+}
 /**
  * publishes jobs based on event type
  * @param  {Object} event event to publish
@@ -91,25 +98,16 @@ const DockerEventPublish = (job) => {
  */
 DockerEventPublish._handlePublish = (event, log) => {
   datadog.incEvent(event)
-  const type = keypather.get(event, 'inspectData.Config.Labels.type')
+
   switch (event.status) {
     case 'create':
-      rabbitmq.publishEvent('container.life-cycle.created', event)
-      if (type) {
-        rabbitmq.publishEvent(`${type}.container.life-cycle.created`, event)
-      }
+      DockerEventPublish._publishEvent('container.life-cycle.created', event)
       break
     case 'start':
-      rabbitmq.publishEvent('container.life-cycle.started', event)
-      if (type) {
-        rabbitmq.publishEvent(`${type}.container.life-cycle.started`, event)
-      }
+      DockerEventPublish._publishEvent('container.life-cycle.started', event)
       break
     case 'die':
-      rabbitmq.publishEvent('container.life-cycle.died', event)
-      if (type) {
-        rabbitmq.publishEvent(`${type}.container.life-cycle.died`, event)
-      }
+      DockerEventPublish._publishEvent('container.life-cycle.died', event)
       break
     case 'engine_connect':
       rabbitmq.createStreamConnectJob('docker', event.Host, event.org)

--- a/lib/workers/docker.event.publish.js
+++ b/lib/workers/docker.event.publish.js
@@ -91,16 +91,25 @@ const DockerEventPublish = (job) => {
  */
 DockerEventPublish._handlePublish = (event, log) => {
   datadog.incEvent(event)
-
+  const type = keypather.get(event, 'inspectData.Config.Labels.type')
   switch (event.status) {
     case 'create':
       rabbitmq.publishEvent('container.life-cycle.created', event)
+      if (type) {
+        rabbitmq.publishEvent(`${type}.container.life-cycle.created`, event)
+      }
       break
     case 'start':
       rabbitmq.publishEvent('container.life-cycle.started', event)
+      if (type) {
+        rabbitmq.publishEvent(`${type}.container.life-cycle.started`, event)
+      }
       break
     case 'die':
       rabbitmq.publishEvent('container.life-cycle.died', event)
+      if (type) {
+        rabbitmq.publishEvent(`${type}.container.life-cycle.died`, event)
+      }
       break
     case 'engine_connect':
       rabbitmq.createStreamConnectJob('docker', event.Host, event.org)

--- a/test/unit/worker/docker.event.publish.js
+++ b/test/unit/worker/docker.event.publish.js
@@ -249,7 +249,7 @@ describe('docker event publish', () => {
       done()
     })
 
-    it('should publish container.life-cycle.created', (done) => {
+    it('should publish container.life-cycle.created and type specific one', (done) => {
       const payload = {
         status: 'create',
         inspectData: {
@@ -270,7 +270,25 @@ describe('docker event publish', () => {
       done()
     })
 
-    it('should publish container.life-cycle.started', (done) => {
+    it('should publish just container.life-cycle.created', (done) => {
+      const payload = {
+        status: 'create',
+        inspectData: {
+          Config: {
+            Labels: {}
+          }
+        }
+      }
+
+      DockerEventPublish._handlePublish(payload)
+
+      sinon.assert.calledOnce(rabbitmq.publishEvent)
+      sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
+      sinon.assert.notCalled(rabbitmq.createStreamConnectJob)
+      done()
+    })
+
+    it('should publish container.life-cycle.started and type specific one', (done) => {
       const payload = {
         status: 'start',
         data: 'big',
@@ -290,7 +308,24 @@ describe('docker event publish', () => {
       done()
     })
 
-    it('should publish container.life-cycle.died', (done) => {
+    it('should publish just container.life-cycle.started', (done) => {
+      const payload = {
+        status: 'start',
+        data: 'big',
+        inspectData: {
+          Config: {
+            Labels: {}
+          }
+        }
+      }
+      DockerEventPublish._handlePublish(payload)
+
+      sinon.assert.calledOnce(rabbitmq.publishEvent)
+      sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.started', payload)
+      done()
+    })
+
+    it('should publish container.life-cycle.died and type specific one', (done) => {
       const payload = {
         status: 'die',
         data: 'big',
@@ -310,23 +345,20 @@ describe('docker event publish', () => {
       done()
     })
 
-    it('should publish container.life-cycle.died', (done) => {
+    it('should publish just container.life-cycle.died', (done) => {
       const payload = {
         status: 'die',
         data: 'big',
         inspectData: {
           Config: {
-            Labels: {
-              type: 'image-builder'
-            }
+            Labels: {}
           }
         }
       }
       DockerEventPublish._handlePublish(payload)
 
-      sinon.assert.calledTwice(rabbitmq.publishEvent)
+      sinon.assert.calledOnce(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.died', payload)
-      sinon.assert.calledWith(rabbitmq.publishEvent, 'image-builder.container.life-cycle.died', payload)
       done()
     })
 

--- a/test/unit/worker/docker.event.publish.js
+++ b/test/unit/worker/docker.event.publish.js
@@ -304,7 +304,7 @@ describe('docker event publish', () => {
       }
 
       DockerEventPublish._handlePublish(payload)
-      sinon.assert.calleTwice(rabbitmq.publishEvent)
+      sinon.assert.calledTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.died', payload)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'user-container.container.life-cycle.died', payload)
       done()

--- a/test/unit/worker/docker.event.publish.js
+++ b/test/unit/worker/docker.event.publish.js
@@ -254,11 +254,10 @@ describe('docker event publish', () => {
           }
         }
       }
-
       DockerEventPublish._publishEvent('container.life-cycle.created', payload)
-
       sinon.assert.calledOnce(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
+      done()
     })
 
     it('should call publishEvent twice if type is user-container', (done) => {
@@ -272,12 +271,11 @@ describe('docker event publish', () => {
           }
         }
       }
-
       DockerEventPublish._publishEvent('container.life-cycle.created', payload)
-
       sinon.assert.calledTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'user-container.container.life-cycle.created', payload)
+      done()
     })
 
     it('should call publishEvent twice if type is image-builder', (done) => {
@@ -291,12 +289,11 @@ describe('docker event publish', () => {
           }
         }
       }
-
       DockerEventPublish._publishEvent('container.life-cycle.created', payload)
-
       sinon.assert.calledTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'image-builder.container.life-cycle.created', payload)
+      done()
     })
 
     it('should call publishEvent once if type is layerCopy', (done) => {
@@ -315,6 +312,7 @@ describe('docker event publish', () => {
 
       sinon.assert.calledOnce(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
+      done()
     })
   })
 

--- a/test/unit/worker/docker.event.publish.js
+++ b/test/unit/worker/docker.event.publish.js
@@ -251,13 +251,21 @@ describe('docker event publish', () => {
 
     it('should publish container.life-cycle.created', (done) => {
       const payload = {
-        status: 'create'
+        status: 'create',
+        inspectData: {
+          Config: {
+            Labels: {
+              type: 'user-container'
+            }
+          }
+        }
       }
 
       DockerEventPublish._handlePublish(payload)
 
-      sinon.assert.calledOnce(rabbitmq.publishEvent)
+      sinon.assert.calledTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
+      sinon.assert.calledWith(rabbitmq.publishEvent, 'user-container.container.life-cycle.created', payload)
       sinon.assert.notCalled(rabbitmq.createStreamConnectJob)
       done()
     })
@@ -265,36 +273,60 @@ describe('docker event publish', () => {
     it('should publish container.life-cycle.started', (done) => {
       const payload = {
         status: 'start',
-        data: 'big'
+        data: 'big',
+        inspectData: {
+          Config: {
+            Labels: {
+              type: 'image-builder'
+            }
+          }
+        }
       }
       DockerEventPublish._handlePublish(payload)
 
-      sinon.assert.calledOnce(rabbitmq.publishEvent)
+      sinon.assert.calledTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.started', payload)
+      sinon.assert.calledWith(rabbitmq.publishEvent, 'image-builder.container.life-cycle.started', payload)
       done()
     })
 
     it('should publish container.life-cycle.died', (done) => {
       const payload = {
         status: 'die',
-        data: 'big'
+        data: 'big',
+        inspectData: {
+          Config: {
+            Labels: {
+              type: 'user-container'
+            }
+          }
+        }
       }
 
       DockerEventPublish._handlePublish(payload)
-      sinon.assert.calledOnce(rabbitmq.publishEvent)
+      sinon.assert.calleTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.died', payload)
+      sinon.assert.calledWith(rabbitmq.publishEvent, 'user-container.container.life-cycle.died', payload)
       done()
     })
 
     it('should publish container.life-cycle.died', (done) => {
       const payload = {
         status: 'die',
-        data: 'big'
+        data: 'big',
+        inspectData: {
+          Config: {
+            Labels: {
+              type: 'image-builder'
+            }
+          }
+        }
       }
       DockerEventPublish._handlePublish(payload)
 
-      sinon.assert.calledOnce(rabbitmq.publishEvent)
+      sinon.assert.calledTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.died', payload)
+      sinon.assert.calledWith(rabbitmq.publishEvent, 'image-builder.container.life-cycle.died', payload)
       done()
     })
 

--- a/test/unit/worker/docker.event.publish.js
+++ b/test/unit/worker/docker.event.publish.js
@@ -255,7 +255,7 @@ describe('docker event publish', () => {
         }
       }
 
-      DockerEventPublish._publishEvent(payload)
+      DockerEventPublish._publishEvent('container.life-cycle.created', payload)
 
       sinon.assert.calledOnce(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
@@ -273,7 +273,7 @@ describe('docker event publish', () => {
         }
       }
 
-      DockerEventPublish._publishEvent(payload)
+      DockerEventPublish._publishEvent('container.life-cycle.created', payload)
 
       sinon.assert.calledTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
@@ -292,7 +292,7 @@ describe('docker event publish', () => {
         }
       }
 
-      DockerEventPublish._publishEvent(payload)
+      DockerEventPublish._publishEvent('container.life-cycle.created', payload)
 
       sinon.assert.calledTwice(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)
@@ -311,7 +311,7 @@ describe('docker event publish', () => {
         }
       }
 
-      DockerEventPublish._publishEvent(payload)
+      DockerEventPublish._publishEvent('container.life-cycle.created', payload)
 
       sinon.assert.calledOnce(rabbitmq.publishEvent)
       sinon.assert.calledWith(rabbitmq.publishEvent, 'container.life-cycle.created', payload)


### PR DESCRIPTION
It's easier with this concrete events to write arithmancy queries. Checking eventName and containerType is getting really complicated for general purpose queries.

It's better to have more specific events in addition to generic events.

Also we would be able to reuse only those events in api and pheidi to reduce load on services and remove extra code checks we have.
